### PR TITLE
Clarify Fixnum#times

### DIFF
--- a/idiomatic_ruby/use_times.md
+++ b/idiomatic_ruby/use_times.md
@@ -1,13 +1,13 @@
 ## Use Fixnum#times
 
-**Use**
+**Instead of**
 ```ruby
 for i in 1..10
   puts 'My iteration'
 end
 ```
 
-**Rather than**
+**Use**
 ```ruby
 5.times do
   puts 'My iteration'


### PR DESCRIPTION
The `Fixnum#times` page seems incorrect - its current wording makes it seem like it's discouraging people from using `times`, but the title is `Use Fixnum#times`