### PR TITLE
Remove the leading space before backticks

### DIFF
--- a/best_practices/using_exception_e.md
+++ b/best_practices/using_exception_e.md
@@ -57,7 +57,7 @@ Exception
    ZeroDivisionError
  SystemExit
  fatal
- ```
+```
 
 **Solution:**
 


### PR DESCRIPTION
The Markdown file might be rendered improperly if there is a leading space before the backticks of fenced code block. 