### PR TITLE
Prefer () as array delimiters

### DIFF
--- a/idiomatic_ruby/array_of_strings_symbols.md
+++ b/idiomatic_ruby/array_of_strings_symbols.md
@@ -3,13 +3,13 @@
 **Array of Strings**
 
 ```ruby
-%w[Michael Jonh Mary Stuart]
+%w(Michael Jonh Mary Stuart)
 => ["Michael", "Jonh", "Mary", "Stuart"]
 ```
 
 **Array of Symbols**
 
 ```ruby
-%i[Michael Jonh Mary Stuart]
+%i(Michael Jonh Mary Stuart)
 => [:Michael, :Jonh, :Mary, :Stuart]
 ```


### PR DESCRIPTION
According to https://github.com/bbatsov/ruby-style-guide#percent-literal-braces