### PR TITLE
Unused Temporary Assignment

### DIFF
--- a/idiomatic_ruby/implicit_return.md
+++ b/idiomatic_ruby/implicit_return.md
@@ -20,7 +20,7 @@ In the following example the explicit return is misleading because even though t
 
 ```ruby
 def odd_or_even(numbers)
-  odd_or_even = numbers.map do |number|
+  numbers.map do |number|
     "odd" if number.odd?
     "even" if number.even?
   end
@@ -30,7 +30,7 @@ odd_or_even([1,2,4,3])
 # returns ["odd", "even", "even", "odd"]
 
 def odd_or_even(numbers)
-  odd_or_even = numbers.map do |number|
+  numbers.map do |number|
     return "odd" if number.odd?
     return "even" if number.even?
   end


### PR DESCRIPTION
It doesn't make any sense to assign the results of the map operations to temporary variables in these methods.